### PR TITLE
Use estimatedDocumentCount to avoid using COLLSCAN

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,9 +41,20 @@ function paginate(query, options, callback) {
     }
 
     var promises = {
-        docs:  Promise.resolve([]),
-        count: this.countDocuments? this.countDocuments(query).exec() : this.count(query).exec()
-    };
+      docs:  Promise.resolve([]),
+      count: (() => {
+          if (query === {}) {
+              if (this.estimatedDocumentCount) {
+                  return this.estimatedDocumentCount()
+              } else {
+                  var fullQuery = { _id: { $ne: null }}
+                  return this.countDocuments? this.countDocuments(fullQuery).exec() : this.count(fullQuery).exec()
+              }
+          } else {
+              this.countDocuments? this.countDocuments(query).exec() : this.count(query).exec()
+          }
+      })()
+  };
 
     if (limit) {
         var query = this.find(query)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-paginate",
   "description": "Pagination plugin for Mongoose",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": {
     "name": "Edward Hotchkiss",
     "email": "edward@edwardhotchkiss.com"


### PR DESCRIPTION
The `countDocument({})` will use the aggregation query as below:
```
pipeline: [ { $match: {} }, { $group: { _id: null, n: { $sum: 1 } } } ]
```
It will search documents by COLLSCAN and not use index.

So, we need to fix the library.
We have two options:

1. using Mongoose's `estimatedDocumentCount`
2. using `{ _id: { $ne: null }}` to use index

----

This is the guide from MongoDB Atlas engineer:

> There were queries doing COLLSCANS:
> However this is not matching on anything so index cannot be created. Including a match clause which has an index (e.g. {_id: {$gt: 0}}) should make such queries use index which would result in less use of memory and system resources.